### PR TITLE
Handle other 40x codes when falling back to 'experimental'

### DIFF
--- a/impl/common/command_processor_test.go
+++ b/impl/common/command_processor_test.go
@@ -60,8 +60,38 @@ var _ = Describe("CommandProcessor", func() {
 			Expect(helper.ExchangeCallCount()).To(Equal(1))
 		})
 
-		It("older url get the response", func() {
+		It("older url gets 404 the response", func() {
 			helper.ExchangeReturnsOnCall(0, "", 404, nil)
+			helper.ExchangeReturnsOnCall(1, "{}", 200, nil)
+			err = commandProcessor.ProcessCommand(&commandData)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Invalid command: "))
+			Expect(len(commandData.AvailableEndpoints)).To(BeZero())
+			Expect(helper.ExchangeCallCount()).To(Equal(2))
+		})
+
+		It("older url gets 401 the response", func() {
+			helper.ExchangeReturnsOnCall(0, "", 401, nil)
+			helper.ExchangeReturnsOnCall(1, "{}", 200, nil)
+			err = commandProcessor.ProcessCommand(&commandData)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Invalid command: "))
+			Expect(len(commandData.AvailableEndpoints)).To(BeZero())
+			Expect(helper.ExchangeCallCount()).To(Equal(2))
+		})
+
+		It("older url gets 403 the response", func() {
+			helper.ExchangeReturnsOnCall(0, "", 403, nil)
+			helper.ExchangeReturnsOnCall(1, "{}", 200, nil)
+			err = commandProcessor.ProcessCommand(&commandData)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Invalid command: "))
+			Expect(len(commandData.AvailableEndpoints)).To(BeZero())
+			Expect(helper.ExchangeCallCount()).To(Equal(2))
+		})
+
+		It("older url gets 407 the response", func() {
+			helper.ExchangeReturnsOnCall(0, "", 407, nil)
 			helper.ExchangeReturnsOnCall(1, "{}", 200, nil)
 			err = commandProcessor.ProcessCommand(&commandData)
 			Expect(err).To(HaveOccurred())

--- a/impl/common/endpoints.go
+++ b/impl/common/endpoints.go
@@ -17,6 +17,7 @@ package common
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"code.cloudfoundry.org/cli/cf/errors"
@@ -32,7 +33,8 @@ func GetEndPoints(commandData *domain.CommandData, requester impl.RequestHelper)
 		return errors.New("unable to reach " + commandData.ConnnectionData.LocatorAddress + ": " + err.Error())
 	}
 
-	if statusCode == 404 {
+	fallbackCodes := "401 403 404 407"
+	if strings.Contains(fallbackCodes, strconv.Itoa(statusCode)) {
 		// if unable to reach /management/v1 then try /management/experimental for older releases
 		apiDocURL = commandData.ConnnectionData.LocatorAddress + "/management/experimental/api-docs"
 		urlResponse, statusCode, err = requester.Exchange(apiDocURL, "GET", nil, nil)


### PR DESCRIPTION
Co-authored-by: Joris Melchior <joris.melchior@gmail.com>
Co-authored-by: Dale Emery <demery@pivotal.io>