### PR TITLE
Parse number from swagger

### DIFF
--- a/ci/deploy_pipeline.sh
+++ b/ci/deploy_pipeline.sh
@@ -248,6 +248,11 @@ for gem in $STANDALONE_GEMFIRE_VERSIONS; do
     - get: golang-image
     - get: gemfire-$gem
 EOF
+if [ $(echo $gem|tr . '\n' | wc -l) -ne 3 ] ; then
+  cat << EOF >> pipeline.yml
+      trigger: true
+EOF
+fi
 function buildPlugin {
   cat << EOF >> pipeline.yml
   - task: build-plugin

--- a/ci/deploy_pipeline.sh
+++ b/ci/deploy_pipeline.sh
@@ -36,7 +36,8 @@ BLESSED_KEY="AKIAJPMW5"G'JQJPVJVR6Q'
 BLESSED_SECRET='n41r3zdlwKCtln'"w22plhTJUhE"/9iBWQmh4p26fPY
 
 # Version(s) of GemFire for stand-alone testing, whitespace-separated
-STANDALONE_GEMFIRE_VERSIONS="9.9 9.10 develop"
+# 3-digit indicates a released version, anything else is latest nightly build"
+STANDALONE_GEMFIRE_VERSIONS="9.9.1 9.9.2 9.9 9.10.0 9.10 develop"
 
 # Version(s) of PCC+stemcell for testing as plugin, whitespace-separated.
 # Last one in the list will be taken from blessed bucket, the rest from pivnet
@@ -49,7 +50,8 @@ cat << EOF > pipeline.yml
 resources:
 EOF
 for gem in $STANDALONE_GEMFIRE_VERSIONS; do
-  if [ "$gem" = "9.9" ] ; then
+  if [ $(echo $gem|tr . '\n' | wc -l) -eq 3 ] ; then
+    mm=${gem%.*}
     cat << EOF >> pipeline.yml
 - name: gemfire-$gem
   type: s3
@@ -59,7 +61,7 @@ for gem in $STANDALONE_GEMFIRE_VERSIONS; do
     region_name: ((aws-default-region))
     access_key_id: ((gemfire-aws-access-key-id))
     secret_access_key: ((gemfire-aws-secret-access-key))
-    versioned_file: 9.9/9.9.0/pivotal-gemfire-9.9.0.tgz
+    versioned_file: ${mm}/${gem}/pivotal-gemfire-${gem}.tgz
 EOF
   else
 [ "$gem" = develop ] && br=develop || br=support/$gem

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -36,8 +36,9 @@ func main() {
 	checkError(err)
 
 	// figure out who is calling. If invoked as a standalone cli
-	if strings.HasSuffix(os.Args[0], "main_go") ||
-		strings.HasSuffix(os.Args[0], "gemfire") {
+	if (strings.HasSuffix(os.Args[0], "main_go") ||
+		strings.HasSuffix(os.Args[0], "gemfire")) &&
+		!strings.Contains(os.Args[0], "cf/plugins") {
 		geodeCommand, err := geode.New(commonCode)
 		checkError(err)
 		err = geodeCommand.Run(os.Args)

--- a/domain/structs.go
+++ b/domain/structs.go
@@ -17,7 +17,7 @@ package domain
 
 import "code.cloudfoundry.org/cli/plugin"
 
-var VersionType = plugin.VersionType{Major: 1, Minor: 0, Build: 6}
+var VersionType = plugin.VersionType{Major: 1, Minor: 0, Build: 7}
 
 // CommandData is all the data involved in executing plugin commands
 // This data gets manipulated throughout the program

--- a/domain/structs.go
+++ b/domain/structs.go
@@ -17,7 +17,7 @@ package domain
 
 import "code.cloudfoundry.org/cli/plugin"
 
-var VersionType = plugin.VersionType{Major: 1, Minor: 0, Build: 5}
+var VersionType = plugin.VersionType{Major: 1, Minor: 0, Build: 6}
 
 // CommandData is all the data involved in executing plugin commands
 // This data gets manipulated throughout the program

--- a/impl/common/endpoints.go
+++ b/impl/common/endpoints.go
@@ -127,6 +127,8 @@ func buildStructure(propertiesMap map[string]domain.PropertyDetail, definitions 
 			}
 		case "integer":
 			structure[key] = 42
+		case "number":
+			structure[key] = 42.42
 		case "boolean":
 			structure[key] = true
 		case "object":

--- a/impl/common/format/strings.go
+++ b/impl/common/format/strings.go
@@ -23,7 +23,7 @@ const (
 		"use --help or -h for help"
 	GenericErrorMessage       = "Cannot retrieve credentials. Error: %s"
 	InvalidServiceKeyResponse = "The cf service-key response is invalid."
-	GeneralOptions            = "\t\t--user, -u <username> or set 'GEODE_USERNAME' environment variable to set the username\n" +
-		"\t\t--password, -p <password> or set 'GEODE_PASSWORD' environment variable to set the password\n" +
-		"\t\t--table, -t [<jqFilter>] to get tabular output"
+	GeneralOptions            = "\t\t--user, -u <username>, or a 'GEODE_USERNAME' environment variable sets the username\n" +
+		"\t\t--password, -p <password>, or a 'GEODE_PASSWORD' environment variable sets the password\n" +
+		"\t\t--table, -t [<jqFilter>] outputs in a tabular form"
 )

--- a/impl/geode/geode_cmd.go
+++ b/impl/geode/geode_cmd.go
@@ -70,14 +70,14 @@ func (gc *command) Run(args []string) (err error) {
 }
 
 func printHelp() {
-	fmt.Println("Commands to interact with geode cluster.")
+	fmt.Println("Commands to interact with a Geode cluster.")
 	fmt.Println("")
 	fmt.Println("Usage: gemfire <target> <command> [options]")
 	fmt.Println("")
-	fmt.Println("\ttarget: \n\t\turl to a geode locator in the form of : http(s)://host:port")
-	fmt.Println("\t\tomit if 'GEODE_TARGET' environment variable is set")
-	fmt.Println("\tcommand:\n\t\tuse 'gemfire <target> commands' to see a list of supported commands")
-	fmt.Println("\toptions:\n\t\tuse 'gemfire <target> <command> -h' to see options for individual command.")
+	fmt.Println("\ttarget: \n\t\tURL to a Geode locator in the form of: http(s)://host:port")
+	fmt.Println("\t\tOptional if 'GEODE_TARGET' environment variable is set")
+	fmt.Println("\tcommand:\n\t\t'gemfire <target> commands' lists available commands")
+	fmt.Println("\toptions:\n\t\t'gemfire <target> <command> -h' lists options for an individual command")
 	fmt.Println(format.GeneralOptions)
-	fmt.Println("\thelp:\n\t\tuse -h or --help for general help, and provide <command> for command specific help.")
+	fmt.Println("\thelp:\n\t\t--help, -h for general help, and provide <target> and <command> for command-specific help")
 }


### PR DESCRIPTION
Currently the swagger parser does not recognize `number` and shows `"unknown"` as a sample value when it encounters it when generating help text for commands. This patch adds the ability to parse this out and give meaningful help.